### PR TITLE
[HC-2488] Convert cakephp-inline-css to be compatible with cakephp 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "cakephp/cakephp": "~3.0",
+        "cakephp/cakephp": "^4.0",
         "tijsverkoyen/css-to-inline-styles": "^1.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "cakephp/cakephp": "^4.0",
-        "tijsverkoyen/css-to-inline-styles": "^1.5"
+        "tijsverkoyen/css-to-inline-styles": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/View/Helper/InlineCssHelper.php
+++ b/src/View/Helper/InlineCssHelper.php
@@ -22,9 +22,7 @@ class InlineCssHelper extends Helper
         }
 
         // Convert inline style blocks to inline CSS on the HTML content.
-        $this->InlineCss->setHTML($content);
-        $this->InlineCss->setUseInlineStylesBlock(true);
-        $content = $this->InlineCss->convert();
+        $content = $this->InlineCss->convert($content);
 
         $this->_View->Blocks->set('content', $content);
 


### PR DESCRIPTION
Update required fields of `cakephp-inline-css` to allow for new versions of `tijsverkoyen/css-to-inline-styles` and cakephp