### PR TITLE
Hcs 716 cake 5 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,12 @@
         }
     ],
     "require": {
-        "cakephp/cakephp": "^3.0|^4.0",
+        "php": ">=7.4",
+        "cakephp/cakephp": "^3.0 || ^4.0 || ^5.0",
         "tijsverkoyen/css-to-inline-styles": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8"
+        "phpunit/phpunit": "^11.1"
     },
     "autoload": {
         "psr-4": {
@@ -28,5 +29,8 @@
             "Cake\\Test\\": "./vendor/cakephp/cakephp/tests",
             "InlineCss\\Test\\": "tests"
         }
+    },
+    "scripts": {
+        "test": "phpunit"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.1/phpunit.xsd"
     colors="true"
     processIsolation="false"
     stopOnFailure="false"
@@ -18,22 +20,11 @@
         <!-- Add plugin test suites here. -->
     </testsuites>
 
-    <!-- Setup a listener for fixtures -->
-    <listeners>
-        <listener
-        class="\Cake\TestSuite\Fixture\FixtureInjector"
-        file="./vendor/cakephp/cakephp/src/TestSuite/Fixture/FixtureInjector.php">
-            <arguments>
-                <object class="\Cake\TestSuite\Fixture\FixtureManager" />
-            </arguments>
-        </listener>
-    </listeners>
-
     <!-- Ignore vendor tests in code coverage reports -->
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory suffix=".php">./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -6,17 +6,29 @@ This plugin provides a CakePHP helper that uses [CssToInlineStyles](https://gith
 
 ## Requirements
 
-* CakePHP 3.x
+* CakePHP 3.x / 4.x / 5.x
 
 ## Installation
 
 This plugin should be installed using Composer:-
 
 ```
-composer require drmonkeyninja/cakephp-inline-css:3.0.*
+composer require drmonkeyninja/cakephp-inline-css
 ```
 
-Then add the following line to your bootstrap.php to load the plugin.
+Then load the plugin in your `Application::bootstrap()` (CakePHP 4.x/5.x):
+
+```php
+$this->addPlugin('InlineCss');
+```
+
+or via the CLI:
+
+```
+bin/cake plugin load InlineCss
+```
+
+On CakePHP 3.x, add the following line to your `bootstrap.php` instead:
 
 ```php
 Plugin::load('InlineCss');
@@ -24,7 +36,19 @@ Plugin::load('InlineCss');
 
 ## Usage
 
-To use this plugin you want to load the `InlineCss` helper to use with your email's HTML template:-
+To use this plugin you want to load the `InlineCss` helper to use with your email's HTML template. On CakePHP 4.x/5.x, using the `Mailer` API:-
+
+```php
+$mailer = new Mailer();
+$mailer->setTemplate('welcome', 'fancy')
+    ->setEmailFormat('html')
+    ->viewBuilder()->setHelpers(['InlineCss.InlineCss']);
+$mailer->setTo('bob@example.com')
+    ->setFrom('app@domain.com')
+    ->send();
+```
+
+On CakePHP 3.x, using the legacy `Email` API:-
 
 ```php
 $email = new Email();

--- a/src/View/Helper/InlineCssHelper.php
+++ b/src/View/Helper/InlineCssHelper.php
@@ -17,12 +17,10 @@ class InlineCssHelper extends Helper
     {
         $content = $this->_View->fetch('content');
 
-        if (!isset($this->InlineCss)) {
-            $this->InlineCss = new CssToInlineStyles();
-        }
+        static $inliner = new CssToInlineStyles();
 
         // Convert inline style blocks to inline CSS on the HTML content.
-        $content = $this->InlineCss->convert($content);
+        $content = $inliner->convert($content);
 
         $this->_View->assign('content', $content);
 

--- a/tests/TestCase/View/Helper/InlineCssHelperTest.php
+++ b/tests/TestCase/View/Helper/InlineCssHelperTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace InlineCss\TestCase\View\Helper;
+namespace InlineCss\Test\TestCase\View\Helper;
 
 use Cake\Event\Event;
 use Cake\Http\ServerRequest;
@@ -9,6 +9,8 @@ use InlineCss\View\Helper\InlineCssHelper;
 
 class InlineCssHelperTest extends TestCase
 {
+
+    public $View = null;
 
     public $InlineCss = null;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,9 @@
 <?php
-require dirname(__DIR__) . '/vendor/cakephp/cakephp/src/basics.php';
+if (file_exists(dirname(__DIR__) . '/vendor/cakephp/cakephp/src/functions.php')) {
+    require dirname(__DIR__) . '/vendor/cakephp/cakephp/src/functions.php';
+} else {
+    require dirname(__DIR__) . '/vendor/cakephp/cakephp/src/basics.php';
+}
 require dirname(__DIR__) . '/vendor/autoload.php';
 if (!defined('DS')) {
     define('DS', DIRECTORY_SEPARATOR);
@@ -28,7 +32,8 @@ define('CAKE_CORE_INCLUDE_PATH', ROOT . '/vendor/cakephp/cakephp');
 define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
 define('CAKE', CORE_PATH . 'src' . DS);
 Cake\Core\Configure::write('App', [
-    'namespace' => 'App'
+    'namespace' => 'App',
+    'encoding' => 'UTF-8'
 ]);
 Cake\Core\Configure::write('debug', true);
 $cache = [


### PR DESCRIPTION
## Summary

Adds CakePHP 5.x support to the plugin while keeping CakePHP 3.x/4.x working, plus a Docker-based dev environment to install/test against a modern PHP/CakePHP stack locally (CI remains out of scope).

- **`composer.json`**: widen `cakephp/cakephp` to `^3.0 || ^4.0 || ^5.0`, add a `"php": ">=7.4"` floor so Composer only resolves Cake 5 on PHP 8.1+, bump `phpunit/phpunit` to `^11.1`, and add a `test` script.
- **`src/View/Helper/InlineCssHelper.php`**: stop writing to the undeclared `$this->InlineCss` property (a PHP 8.2+ "creation of dynamic property" deprecation under Cake 5) in favor of a `static` local `$inliner`. The `Cake\Event\Event` type hint is left as-is — it's valid across 3.x/4.x/5.x, so switching to `EventInterface` would break Cake 3.0–3.5 for no benefit.
- **`phpunit.xml.dist`**: migrated to the PHPUnit 11 schema (`<source><include>` instead of the removed `<filter><whitelist>`) and dropped the `FixtureInjector`/`FixtureManager` listener — those classes were removed in Cake 5 and the suite doesn't use fixtures anyway.
- **`tests/`**: fixed the test class namespace (`InlineCss\TestCase\...` → `InlineCss\Test\TestCase\...`) to match the `autoload-dev` PSR-4 map; updated `bootstrap.php` to require `functions.php` when present (Cake 5 — `basics.php` was removed) falling back to `basics.php` (Cake 3/4), and set `App.encoding` explicitly since Cake 5's `Response`/`HtmlHelper`/`FormHelper`/`Mailer\Message` read it directly and hit deprecation notices when it's unset.
- **`readme.md`**: documents 3.x/4.x/5.x support, the modern `addPlugin()`/`bin/cake plugin load` bootstrap (with the Cake 3 `Plugin::load()` fallback), and a Cake 4/5 `Mailer`-based usage example alongside the legacy `Email` one.
- **Docker dev environment** (`docker/Dockerfile`, `docker-compose.yml`, `Makefile`): a `php:8.3-cli` container with the extensions CakePHP needs (`intl`, `mbstring`, `pdo_sqlite`) for reproducibly running `composer install`/`vendor/bin/phpunit` without depending on host PHP. `make setup` / `make test` / `make shell` wrap the common commands.

## Test plan

Verified inside the Docker `app` service:
- [x] `composer install` resolves and `vendor/bin/phpunit` passes against CakePHP 5 on PHP 8.3, with no dynamic-property or encoding deprecation notices.
- [x] Test class is discovered correctly after the namespace fix (`composer dump-autoload` PSR-4 clean).

Not covered by this PR (CI is out of scope): automated matrix testing against CakePHP 3.x/4.x.
